### PR TITLE
Adjust parallel processing for assemble_reads.py

### DIFF
--- a/secapr/assemble_reads.py
+++ b/secapr/assemble_reads.py
@@ -76,18 +76,28 @@ def assembly_spades(sorted_fastq_files,n_library_numbers,output_folder,id_sample
         kmer,
         "--only-assembler"
     ]
-    for i in np.arange(n_library_numbers):
+    if len(sorted_fastq_files) < 3:
         command += [
         "--pe-1",
-        i+1,
-        sorted_fastq_files[i*3],
+        1,
+        sorted_fastq_files[0],
         "--pe-2",
-        i+1,
-        sorted_fastq_files[i*3+1],
-        "--pe-s",
-        i+1,
-        sorted_fastq_files[i*3+2],
+        1,
+        sorted_fastq_files[1],
         ]
+    else:
+        for i in np.arange(n_library_numbers):
+            command += [
+            "--pe-1",
+            i+1,
+            sorted_fastq_files[i*3],
+            "--pe-2",
+            i+1,
+            sorted_fastq_files[i*3+1],
+            "--pe-s",
+            i+1,
+            sorted_fastq_files[i*3+2],
+            ]
     command += ["-o", output_folder]
     if args.cores > 1:
         command+=["--threads", args.cores]
@@ -155,6 +165,8 @@ def process_subfolder(pool_args):
     fastq_files = glob.glob(os.path.join(subfolder,'*.fastq.gz'))
     sorted_fastq_files = ['']*len(fastq_files)
     n_library_numbers = int(len(fastq_files) / 3)
+    if n_library_numbers == 0:      # if there are fewer than three *.fastq.gz files
+        n_library_numbers = 1
     for element in fastq_files:
         for i in np.arange(n_library_numbers):
             if element.endswith("_%i_clean-READ1.fastq.gz"%i):

--- a/secapr/paralogs_to_ref.py
+++ b/secapr/paralogs_to_ref.py
@@ -110,7 +110,11 @@ def main(args):
         ref_seqs = list(SeqIO.parse(ref_file, "fasta"))
         contig_seqs = list(SeqIO.parse(contig_file, "fasta"))
         contig_orientation_df = pd.read_csv(contig_orientation,sep='\t')
-        para_data = genfromtxt(para_info, delimiter='\t')
+        #para_data = genfromtxt(para_info, delimiter='\t')
+        para_data = []
+        with open(para_info, 'r') as para_file:
+            for line in para_file:
+                para_data.append(line.strip().split('\t'))
         print('%i paralogous loci found.'%len(para_data))
         sample_out_dir = os.path.join(outdir,sample)
         if not os.path.exists(sample_out_dir):
@@ -125,11 +129,12 @@ def main(args):
             reference_id = id_ref_dict[reference]
             ref_seq = [ref for ref in ref_seqs if reference_id==ref.id][0]
             records.append(ref_seq)
-            contig_list_tmp = i[1:]
-            contig_list = np.unique(contig_list_tmp[~np.isnan(contig_list_tmp)].astype(int).astype(str))
+            #contig_list_tmp = i[1:]
+            #contig_list = np.unique(contig_list_tmp[~np.isnan(contig_list_tmp)].astype(int).astype(str))
+            contig_list = i[1:]
             for contig_id in contig_list:
                 contig_seq = [contig for contig in contig_seqs if contig_id == contig.id][0]
-                orientation = contig_orientation_df[contig_orientation_df.contig_id == int(contig_id)].orientation.values[0]
+                orientation = contig_orientation_df[contig_orientation_df.contig_id == contig_id].orientation.values[0]
                 if orientation == 'plus':
                     pass
                 else:

--- a/secapr/paralogs_to_ref.py
+++ b/secapr/paralogs_to_ref.py
@@ -69,7 +69,7 @@ def fix_line_wrap(alignment_file):
         line = line.strip()
         if line.startswith(">"):
             id = line
-            final[id] = " "
+            final[id] = ""
         else:
             final[id] += line    
     file_out = open(alignment_file, "w")    


### PR DESCRIPTION
It seems like (based on my tests on my computer) that the current version of the script will actually create "cores" number of parallel assemblies, each using "cores" cores and "max_memory". This is not what I think makes sense, as it will go way beyond the actual "max_memory" setting and available cores. I've added an argument, "instances" that makes it more explicit. Now, the "cores" argument is per SPAdes assembly, the "max_memory" argument is per SPAdes assembly, and the "instances" determines how many the user wants to run in parallel. The actual demand on the system is "instances" * "cores" and "instances" * "max_memory".

It seems like this is what was perhaps going to be implemented, given "cores" and "max_memory" are passed to the spades_assembly function along with "args", but neither "cores" nor "max_memory" are used in the function (just "args.cores" and "args.max_memory"), leading to the weird behaviour.

There may be other ways to ideally fix this behaviour, so perhaps this pull request is not desired.

Cheers,
Ben