### PR TITLE
Fix paralogs_to_ref.py

### DIFF
--- a/secapr/paralogs_to_ref.py
+++ b/secapr/paralogs_to_ref.py
@@ -110,7 +110,11 @@ def main(args):
         ref_seqs = list(SeqIO.parse(ref_file, "fasta"))
         contig_seqs = list(SeqIO.parse(contig_file, "fasta"))
         contig_orientation_df = pd.read_csv(contig_orientation,sep='\t')
-        para_data = genfromtxt(para_info, delimiter='\t')
+        #para_data = genfromtxt(para_info, delimiter='\t')
+        para_data = []
+        with open(para_info, 'r') as para_file:
+            for line in para_file:
+                para_data.append(line.strip().split('\t'))
         print('%i paralogous loci found.'%len(para_data))
         sample_out_dir = os.path.join(outdir,sample)
         if not os.path.exists(sample_out_dir):
@@ -125,11 +129,12 @@ def main(args):
             reference_id = id_ref_dict[reference]
             ref_seq = [ref for ref in ref_seqs if reference_id==ref.id][0]
             records.append(ref_seq)
-            contig_list_tmp = i[1:]
-            contig_list = np.unique(contig_list_tmp[~np.isnan(contig_list_tmp)].astype(int).astype(str))
+            #contig_list_tmp = i[1:]
+            #contig_list = np.unique(contig_list_tmp[~np.isnan(contig_list_tmp)].astype(int).astype(str))
+            contig_list = i[1:]
             for contig_id in contig_list:
                 contig_seq = [contig for contig in contig_seqs if contig_id == contig.id][0]
-                orientation = contig_orientation_df[contig_orientation_df.contig_id == int(contig_id)].orientation.values[0]
+                orientation = contig_orientation_df[contig_orientation_df.contig_id == contig_id].orientation.values[0]
                 if orientation == 'plus':
                     pass
                 else:

--- a/secapr/paralogs_to_ref.py
+++ b/secapr/paralogs_to_ref.py
@@ -69,7 +69,7 @@ def fix_line_wrap(alignment_file):
         line = line.strip()
         if line.startswith(">"):
             id = line
-            final[id] = " "
+            final[id] = ""
         else:
             final[id] += line    
     file_out = open(alignment_file, "w")    


### PR DESCRIPTION
This first makes a small change that was inserting a space at the start of the fasta alignment.
Secondly, it changes the way the script reads the paralog info text file so that contig names are actually retained. Originally, the numpy function genfromtxt would read in only the ref number and leave the contig names as 'nan', leading to no paralogs being aligned to reference sequences. I've changed this to read in as a list. As a result, I had to slightly alter the later code to account for the new data structure.