### PR TITLE
Correct previous patch for numpy.int64 values as fasta sequence names

### DIFF
--- a/secapr/paralogs_to_ref.py
+++ b/secapr/paralogs_to_ref.py
@@ -105,7 +105,11 @@ def main(args):
         # read the data
         ref_index_df = pd.read_csv(ref_index_info,sep='\t',header=None)
         keys = ref_index_df[0].values
+<<<<<<< HEAD
         values = [val.split()[0] for val in ref_index_df[1].values]
+=======
+        values = [str(val).split()[0] for val in ref_index_df[1].values]
+>>>>>>> dccfb62... Now corrected for numpy.int64 values
         id_ref_dict = dict(list(zip(keys,values)))
         ref_seqs = list(SeqIO.parse(ref_file, "fasta"))
         contig_seqs = list(SeqIO.parse(contig_file, "fasta"))


### PR DESCRIPTION
This is a small patch to correct the previous correction for reading the fasta reference ids. If the reference id is a single number, it seems like pandas reads it as an int and therefore the .split() raises an error. This should avoid that problem.